### PR TITLE
Fix swtich am or pm

### DIFF
--- a/lib/js/index.js
+++ b/lib/js/index.js
@@ -159,7 +159,7 @@ class DateTimePicker extends Events {
   clickAm() {
     if (this.meridiem === 'pm') {
       this.meridiem = 'am';
-      this.value.hour(this.value.hour() + 12);
+      this.value.hour(this.value.hour() - 12);
     }
     this.setTime(this.value);
     return this;
@@ -168,7 +168,7 @@ class DateTimePicker extends Events {
   clickPm() {
     if (this.meridiem === 'am') {
       this.meridiem = 'pm';
-      this.value.hour(this.value.hour() - 12);
+      this.value.hour(this.value.hour() + 12);
     }
     this.setTime(this.value);
     return this;


### PR DESCRIPTION
I think if switching am to pm, must be increase 12 hours.

This is a demo page result - if you click time before switching meridiem, you will lose a day.
![bug](https://cloud.githubusercontent.com/assets/5094008/21902190/f38a8cbc-d935-11e6-90e1-fa2247e29a50.gif)
