### PR TITLE
Avoid styles to be broken by MaterializeCSS

### DIFF
--- a/dist/material-datetime-picker.css
+++ b/dist/material-datetime-picker.css
@@ -32,6 +32,7 @@
     top: 50%; }
 
 .c-datepicker__header {
+  box-sizing: content-box;
   position: relative; }
 
 .c-datepicker__header-day {
@@ -52,6 +53,8 @@
   background: #00bcd4;
   height: 150px;
   padding: 16px 0; }
+  .c-datepicker__header-date span {
+    line-height: 1.2; }
 
 .rd-month-label {
   height: 56px;
@@ -159,7 +162,9 @@
   font-size: 12px;
   height: 36px; }
 
-.c-datepicker__day-head, c-datepicker__day-body {
+.c-datepicker__day-head, .c-datepicker__day-body {
+  padding: 0;
+  text-align: center;
   -webkit-tap-highlight-color: transparent; }
 
 .modal-btns {
@@ -187,7 +192,10 @@
   right: 0; }
 
 .c-datepicker__days {
-  margin: 10px 20px; }
+  margin: 10px 20px;
+  width: auto; }
+  .c-datepicker__days .c-datepicker__days-head {
+    border: none; }
 
 .c-datepicker__header-toggle {
   position: absolute;
@@ -214,8 +222,11 @@
   opacity: 0.5;
   z-index: 1;
   transition: opacity 200ms ease-in-out; }
+  .c-datepicker__toggle:checked {
+    opacity: 1; }
 
 .c-datepicker__toggle--right {
+  left: initial;
   right: 10px; }
 
 .c-datepicker__toggle--left {
@@ -239,6 +250,7 @@
   border-radius: 50%;
   list-style: none;
   /* [2] */
+  box-sizing: content-box;
   font-size: 14px;
   line-height: 50px;
   padding: 160px 0 20px 0;

--- a/lib/scss/material-datetime-picker.scss
+++ b/lib/scss/material-datetime-picker.scss
@@ -45,6 +45,7 @@ $primary: #00bcd4;
 }
 
 .c-datepicker__header {
+  box-sizing: content-box;
   position: relative;
 }
 
@@ -68,6 +69,10 @@ $primary: #00bcd4;
   background: $primary;
   height: 150px;
   padding: 16px 0;
+
+  span {
+    line-height: 1.2;
+  }
 }
 
 .c-datepicker__month {
@@ -214,7 +219,9 @@ $primary: #00bcd4;
   height: 36px;
 }
 
-.c-datepicker__day-head, c-datepicker__day-body {
+.c-datepicker__day-head, .c-datepicker__day-body {
+  padding: 0;
+  text-align: center;
   -webkit-tap-highlight-color: rgba(0,0,0,0);
 }
 
@@ -250,6 +257,11 @@ $primary: #00bcd4;
 
 .c-datepicker__days {
   margin: 10px 20px;
+  width: auto;
+
+  .c-datepicker__days-head {
+    border: none;
+  }
 }
 
 .c-datepicker__header-toggle {
@@ -283,9 +295,14 @@ $primary: #00bcd4;
   opacity: 0.5;
   z-index: 1;
   transition: opacity 200ms ease-in-out;
+
+  &:checked {
+    opacity: 1;
+  }
 }
 
 .c-datepicker__toggle--right {
+  left: initial;
   right: 10px;
 }
 
@@ -368,6 +385,7 @@ $primary: #00bcd4;
 
 .c-datepicker__clock {
   @include putOnCircle(12, 200px, 50px);
+  box-sizing: content-box;
   font-size: 14px;
   line-height: 50px;
   padding: 160px 0 20px 0;


### PR DESCRIPTION
It specifies some standard styles that get overrided by the library
MaterializeCSS:
  - `box-content` set to value content-box for __header and __clock.
  - `line-height` set to 1.2 for span inside header-date.
  - removes `padding` and set `text-align` to center for td elements.
  - fix `width` to auto on __days because MaterializeCSS specify its width.

It doesn't fix z-index related issues because I didn't know what could
be the best approach to resolve that.

Related #115