### PR TITLE
Add get method; deprecate data method; fix set bug

### DIFF
--- a/lib/js/__tests__/helpers/open-picker.js
+++ b/lib/js/__tests__/helpers/open-picker.js
@@ -1,0 +1,11 @@
+import delay from "delay";
+import MaterialDatetimePicker from "../../";
+
+// return a Promise to create a picker. open it, and have it interactive in the DOM
+// the delay is to wait for the open transition.
+export default async function openPicker(options) {
+  const picker = new MaterialDatetimePicker(options);
+  picker.open();
+  await delay(300);
+  return picker;
+}

--- a/lib/js/__tests__/index-test.js
+++ b/lib/js/__tests__/index-test.js
@@ -31,6 +31,24 @@ test("closing the picker removes elements from the dom", async () => {
 
   expect($picker).toBeNull();
   expect($backdrop).toBeNull();
+
+// TODO deprecated
+test("picker#data() returns the selected date as a `moment` object", async () => {
+  const startTimestamp = Date.now();
+  const picker = await openPicker();
+
+  expect(+picker.data() - startTimestamp).toBeLessThan(60 * 60 * 10000); // TODO set the time so we can assert on a known value
+  expect(picker.data()._isAMomentObject).toBe(true);
+})
+
+test("picker#get returns the selected date as a `moment` object", async () => {
+  const startTimestamp = Date.now();
+  const picker = await openPicker();
+
+  expect(+picker.get() - startTimestamp).toBeLessThan(60 * 60 * 10000); // TODO set the time so we can assert on a known value
+  expect(picker.get()._isAMomentObject).toBe(true);
+})
+
 // TODO deprecated
 test("picker#data(momentObject) sets the selected date", async () => {
   const startIsoTime = "2017-02-01T18:00:00.000Z";

--- a/lib/js/__tests__/index-test.js
+++ b/lib/js/__tests__/index-test.js
@@ -1,14 +1,10 @@
 import delay from "delay";
+import moment from "moment";
+
+import openPicker from "./helpers/open-picker";
 import MaterialDatetimePicker from "../";
 
 const $ = document.querySelector.bind(document);
-
-async function openPicker(options) {
-  const picker = new MaterialDatetimePicker(options);
-  picker.open();
-  await delay(300);
-  return picker;
-}
 
 afterEach(() => {
   document.body.innerHTML = "";
@@ -35,4 +31,49 @@ test("closing the picker removes elements from the dom", async () => {
 
   expect($picker).toBeNull();
   expect($backdrop).toBeNull();
-});
+// TODO deprecated
+test("picker#data(momentObject) sets the selected date", async () => {
+  const startIsoTime = "2017-02-01T18:00:00.000Z";
+  const startMoment = moment(startIsoTime);
+  const picker = await openPicker();
+
+  picker.set(startMoment);
+  expect(picker.data().toISOString()).toEqual(startIsoTime);
+})
+
+test("picker#set(momentObject) sets the selected date", async () => {
+  // FIXME 17:30 is rounded up to 18:00, which is inconsistent with
+  // default. Fix: apply the same minute rounding (no hour rounding) to both.
+  const startIsoTime = "2017-02-01T18:30:00.000Z";
+  const startMoment = moment(startIsoTime);
+  const picker = await openPicker();
+
+  picker.set(startMoment);
+  expect(picker.data().toISOString()).toEqual(startIsoTime);
+})
+
+test("picker#set(DateObject) sets the selected date", async () => {
+  const startIsoTime = "2017-02-01T18:00:00.000Z";
+  const startDate = new Date(startIsoTime);
+  const picker = await openPicker();
+
+  picker.set(startDate);
+  expect(picker.data().toISOString()).toEqual(startIsoTime);
+})
+
+test("picker#set(isoTimeString) sets the selected date", async () => {
+  const startIsoTime = "2017-02-01T18:00:00.000Z";
+  const picker = await openPicker();
+
+  picker.set(startIsoTime);
+  expect(picker.data().toISOString()).toEqual(startIsoTime);
+})
+
+test("picker#set(timestampInMillis) sets the selected date", async () => {
+  const startIsoTime = "2017-02-01T18:00:00.000Z";
+  const startTimestamp = +(new Date(startIsoTime));
+  const picker = await openPicker();
+
+  picker.set(startTimestamp);
+  expect(picker.data().toISOString()).toEqual(startIsoTime);
+})

--- a/lib/js/__tests__/index-test.js
+++ b/lib/js/__tests__/index-test.js
@@ -31,6 +31,14 @@ test("closing the picker removes elements from the dom", async () => {
 
   expect($picker).toBeNull();
   expect($backdrop).toBeNull();
+});
+
+test("opening the picker with a default time", async () => {
+  const time = "2017-02-01T17:30:00.000Z";
+  const picker = await openPicker({ default: moment(time) });
+
+  expect(picker.data().toISOString()).toEqual(time);
+});
 
 // TODO deprecated
 test("picker#data() returns the selected date as a `moment` object", async () => {

--- a/lib/js/index.js
+++ b/lib/js/index.js
@@ -299,7 +299,9 @@ class DateTimePicker extends Events {
     ) {
       this.setDate(m);
       evts.push('change:date');
-    } else if (m.hour() !== this.value.hour()
+    } 
+    
+    if (m.hour() !== this.value.hour()
       || m.minutes() !== this.value.minutes()
     ) {
       this.setTime(m);

--- a/lib/js/index.js
+++ b/lib/js/index.js
@@ -282,7 +282,12 @@ class DateTimePicker extends Events {
   }
 
   data(val) {
+    console.warn(`MaterialDatetimePicker#data is deprecated and will be removed in a future release. Please use get or set.`)
     return (val ? this.set(val) : this.value);
+  }
+
+  get() {
+    return moment(this.value);
   }
 
   // update the picker's date/time value


### PR DESCRIPTION
* [x] Ready to merge

-----

Fix #122 (I realised `data(newValue)` was set when writing these unit tests).