### PR TITLE
Allow SCSS variables to be overridden by users

### DIFF
--- a/lib/scss/material-datetime-picker.scss
+++ b/lib/scss/material-datetime-picker.scss
@@ -1,5 +1,5 @@
-$lowlight: #0097a7;
-$primary: #00bcd4;
+$lowlight: #0097a7 !default;
+$primary: #00bcd4 !default;
 
 .c-scrim {
   position: fixed;


### PR DESCRIPTION
By adding `!default`, variables defined before the picker SCSS is imported, can be overridden by the user.